### PR TITLE
Fix: Update uploading ticket image

### DIFF
--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -54,38 +54,33 @@ export default function Ticket({}) {
 
                                 const { data, error } = await supabase.storage
                                     .from('Tickets Images')
-                                    .getPublicUrl(
+                                    .download(
                                         `Ticket-de-@${userInfo.username_github}.png`
                                     )
 
-                                if (error) {
-                                    console.error(
-                                        'Error al verificar la existencia de la imagen:',
-                                        error.message
-                                    )
+                                if (error && error.message === "The resource was not found") {
+                                    // La imagen no existe, realizar la subida
+                                    const response = await fetch(imgData)
+                                    const blob = await response.blob()
+
+                                    const {
+                                        data: uploadData,
+                                        error: uploadError,
+                                    } = await supabase.storage
+                                        .from('Tickets Images')
+                                        .upload(
+                                            `Ticket-de-@${userInfo.username_github}.png`,
+                                            blob
+                                        )
+
+                                    if (uploadError) {
+                                        console.error(
+                                            'Error al subir la imagen:',
+                                            uploadError.message
+                                        )
+                                    }
                                 } else {
-                                    if (data.publicUrl) {
-                                        // La imagen no existe, realizar la subida
-                                        const response = await fetch(imgData)
-                                        const blob = await response.blob()
-
-                                        const {
-                                            data: uploadData,
-                                            error: uploadError,
-                                        } = await supabase.storage
-                                            .from('Tickets Images')
-                                            .upload(
-                                                `Ticket-de-@${userInfo.username_github}.png`,
-                                                blob
-                                            )
-
-                                        if (uploadError) {
-                                            console.error(
-                                                'Error al subir la imagen:',
-                                                uploadError.message
-                                            )
-                                        }
-                                    } else {
+                                    if (data) {
                                         console.log(
                                             'La imagen ya existe en el almacenamiento de Supabase.'
                                         )


### PR DESCRIPTION
Hola

Ajusto flujo en la generación de Ticket:

- Actualmente, la función `getPublicUrl` siempre devolverá un valor truthy de una URL para Supabase por más que no exista, se usa `download`, que te devolverá la imagen si existe o un error sino, si se presenta un error se realiza la carga del ticket al storage

- De igual forma, se debería ajustar el código, debido a que la carga de la imagen del ticket al storage, no se debería hacer sobre el homepage con el query-string `username`, sino debería hacer al momento exacto de la creación del ticket

**Cambiar variable de entorno `PUBLIC_SUPABASE_URL` por `https://gspoweotoxbkldntqhxb.supabase.co`**