### PR TITLE
Fix: Update IDs in menu to scroll to schedule

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,7 +12,7 @@ const menu: MenuLink[] = [
     },
     {
         name: 'Horario y Charlas',
-        anchor: '#participantes',
+        anchor: '#horarios',
     },
     {
         name: 'Genera tu ticket',

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -47,9 +47,8 @@ const items: typeItem[] = [
 ]
 ---
 
-<section class="py-16 flex flex-col gap-24 px-18 p-8">
+<section class="py-16 flex flex-col gap-24 px-18 p-8" id="horarios">
     <h2
-        id="horarios"
         class="font-extrabold text-4xl text-transparent bg-clip-text from-[#c8f2f5] to-[#46c6cf] bg-gradient-to-b text-center"
     >
         Horarios y charlas


### PR DESCRIPTION
- [x] Actualice el ID “participantes” a “horarios” en el menú para que al hacer clic en el botón “Horarios y charlas” se haga el scroll automático hasta dicha sección en la página.
- [x] Corregí la posición del ID “horarios” en el Schedule, pasando la misma del "h2" al "section" para seguir el mismo tipo de asignación de IDs que se sigue en otras secciones de la página.

![imagen](https://github.com/Afordin/aforshow/assets/49946109/6ad899f1-7062-4792-b982-2c1ad40be3cd)
